### PR TITLE
feat: finalize devpi configuration and publish workflow documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,37 @@ uv publish --index-url http://localhost:3141/gautada/dev/
 
 - [devpi documentation](https://devpi.net/docs/devpi/devpi/stable/+d/index.html)
 - [devpi on PyPI](https://pypi.org/project/devpi-server/)
+
+## Publishing a Python Package (e.g. dyndns)
+
+Once the container is running, the \`gautada/dev\` index is created automatically on first start.
+
+### One-time client setup (on your machine)
+
+```shell
+pip install devpi-client
+devpi use http://<devpi-host>:3141/gautada/dev/
+devpi login gautada --password=''
+```
+
+### Publish with uv
+
+```shell
+cd /path/to/your/python/package
+uv build
+uv publish --index-url http://<devpi-host>:3141/gautada/dev/
+```
+
+### Install from the private index
+
+```shell
+uv pip install --index-url http://<devpi-host>:3141/gautada/dev/ your-package
+```
+
+### Upstream PyPI proxy
+
+The \`root/pypi\` index proxies and caches upstream PyPI. Configure \`uv\` to use it:
+
+```shell
+uv pip install --index-url http://<devpi-host>:3141/root/pypi/ requests
+```

--- a/devpi-entrypoint.sh
+++ b/devpi-entrypoint.sh
@@ -2,13 +2,45 @@
 set -e
 
 DATA_DIR=/mnt/volumes/data
+DEVPI=/opt/devpi/bin/devpi-server
+DEVPI_CLIENT=/opt/devpi/bin/devpi
 
 # Initialize devpi on first run
 if [ ! -f "${DATA_DIR}/.nodeinfo" ]; then
+  echo "[devpi] Initializing data directory..."
   /opt/devpi/bin/devpi-init --serverdir "${DATA_DIR}"
+
+  echo "[devpi] Starting server temporarily for index setup..."
+  "$DEVPI" --serverdir "${DATA_DIR}" --host 127.0.0.1 --port 3141 &
+  SERVER_PID=$!
+
+  # Wait for server to become ready (max 30s)
+  i=0
+  while ! curl -sf http://127.0.0.1:3141/+api > /dev/null 2>&1; do
+    sleep 1
+    i=$((i + 1))
+    if [ "$i" -ge 30 ]; then
+      echo "[devpi] ERROR: server did not start within 30 seconds" >&2
+      kill "$SERVER_PID" 2>/dev/null || true
+      exit 1
+    fi
+  done
+
+  echo "[devpi] Creating gautada/dev private index..."
+  "$DEVPI_CLIENT" use http://127.0.0.1:3141
+  "$DEVPI_CLIENT" login root --password=''
+  "$DEVPI_CLIENT" user -c gautada email=admin@example.com password=''
+  "$DEVPI_CLIENT" login gautada --password=''
+  "$DEVPI_CLIENT" index -c dev bases=root/pypi || true
+  "$DEVPI_CLIENT" logoff
+
+  echo "[devpi] Stopping temporary server..."
+  kill "$SERVER_PID"
+  wait "$SERVER_PID" 2>/dev/null || true
+  echo "[devpi] Index setup complete."
 fi
 
-exec /opt/devpi/bin/devpi-server \
+exec "$DEVPI" \
   --serverdir "${DATA_DIR}" \
   --host 0.0.0.0 \
   --port 3141


### PR DESCRIPTION
Finalize devpi-server configuration with auto-creation of the gautada/dev private index on first run. Documents the uv/pip publish workflow and PyPI proxy usage in README.

References #1